### PR TITLE
Moving unload to beforeunload

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -24,7 +24,7 @@ for (var i = 0, l = pixelFunc.queue.length; i < l; i++) {
   pixelFunc.process.apply(pixelFunc, pixelFunc.queue[i]);
 }
 
-window.addEventListener('unload', function() {
+window.addEventListener('beforeunload', function() {
   if (!Config.pageCloseOnce) {
     Config.pageCloseOnce = true;
     // set 10 minutes page close cookie


### PR DESCRIPTION
As I was testing this locally, I noticed I wouldn't get pageclose events when I navigated away from my site or closed the tab. Moving the pageclose from unload to beforeunload addressed the issue.

Google has some good documentation on lifecycle APIs which calls out that unload is unreliable. https://developers.google.com/web/updates/2018/07/page-lifecycle-api#legacy-lifecycle-apis-to-avoid. In a perfect world, we could migrate to the newer events that don't have page navigation cache issues, but I don't know what your browser compatibility threshold is.