### PR TITLE
More accurate page close event handling

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -32,8 +32,8 @@ var isSafari = typeof safari === 'object' && safari.pushNotification;
 // pagehide event is more reliable but less broad than unload event for mobile and modern browsers
 var pageCloseEvent = 'onpageshow' in self && !isSafari ? 'pagehide' : 'unload';
 
-if (!Config.pageCloseOnce) {
-  window.addEventListener(pageCloseEvent, function() {
+window.addEventListener(pageCloseEvent, function() {
+  if (!Config.pageCloseOnce) {
     Config.pageCloseOnce = true;
     new Pixel('pageclose', Helper.now(), function() {
       // if a link was clicked in the last 5 seconds that goes to an external host, pass it through as event data
@@ -41,8 +41,8 @@ if (!Config.pageCloseOnce) {
         return Config.externalHost.link;
       }
     });
-  });
-}
+  }
+});
 
 window.onload = function() {
   var aTags = document.getElementsByTagName('a');

--- a/src/setup.js
+++ b/src/setup.js
@@ -30,7 +30,7 @@ var isSafari = typeof safari === 'object' && safari.pushNotification;
 
 // IE9-10 do not support the pagehide event, so we fall back to unload
 // pagehide event is more reliable but less broad than unload event for mobile and modern browsers
-var pageCloseEvent = 'onpageshow' in self && !is_safari ? 'pagehide' : 'unload';
+var pageCloseEvent = 'onpageshow' in self && !isSafari ? 'pagehide' : 'unload';
 
 if (!Config.pageCloseOnce) {
   window.addEventListener(pageCloseEvent, function() {

--- a/src/setup.js
+++ b/src/setup.js
@@ -26,11 +26,15 @@ for (var i = 0, l = pixelFunc.queue.length; i < l; i++) {
 
 // https://github.com/GoogleChromeLabs/page-lifecycle/blob/master/src/Lifecycle.mjs
 // Safari does not reliably fire the `pagehide` or `visibilitychange`
-var isSafari = typeof safari === 'object' && safari.pushNotification;
+var isNotSafari = !(typeof safari === 'object' && safari.pushNotification);
+var isPageHideSupported = 'onpageshow' in self;
 
 // IE9-10 do not support the pagehide event, so we fall back to unload
 // pagehide event is more reliable but less broad than unload event for mobile and modern browsers
-var pageCloseEvent = 'onpageshow' in self && !isSafari ? 'pagehide' : 'unload';
+var pageCloseEvent =
+  isPageHideSupported && isNotSafari
+    ? 'pagehide'
+    : 'unload';
 
 window.addEventListener(pageCloseEvent, function() {
   if (!Config.pageCloseOnce) {


### PR DESCRIPTION
This PR contains a more accurate way to detect page close events on desktop and mobile browsers. `pagehide`, `visibilitychange`, and `unload`, each of these events is not reliable and not broad among desktop and mobile devices.

The way that page close event handled in this PR may not be the best or most proper. I would be very happy to discuss/find out the best way here.

This PR relates to https://github.com/dockwa/openpixel/pull/82#issuecomment-656444935

**Note:** This pull request is not tested. I just could not have enough time to do some tests. If I have time, I am going to do.